### PR TITLE
[#4085] Fix RQM so that it can merge the branch.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# Order is important. The last matching pattern has the most precedence.
+# See https://help.github.com/articles/about-codeowners/
+
+# All code is reviewed by the developers.
+* @adiroiban

--- a/README.rst
+++ b/README.rst
@@ -49,5 +49,5 @@ Paver Script
 The paver.sh script should be kept in sync with the version from the
 chevah/python-package repository.
 
-Changes to paver.sh don't need an update in version as they are not
-versioned (yet).
+Changes to paver.sh do not need an update in version as they are not
+versioned yet.

--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,6 @@ Each change needs a dedicated ticket and a dedicated branch::
 
 Create a PR and request a review.
 
-Run `./paver.sh test_review` to trigger the tests required before merge.
-
 Once all the required tests are green and you have a review,
 you can merge from GitHub's merge button.
 
@@ -42,11 +40,14 @@ format as earlier releases (see the file contents).
 Note: The release-notes fragment files are only used on chevah/server, so the
 fragments folder was moved to brink/tests/release-notes on this package.
 
+Once a new version is merged, publish it to our package index server.
+
 
 Paver Script
 ============
 
-The paver.sh script we use is taken from chevah/python-package repository.
+The paver.sh script should be kept in sync with the version from the
+chevah/python-package repository.
 
-If modifications to paver.sh file are required, they should be done on a
-branch on that repository.
+Changes to paver.sh don't need an update in version as they are not
+versioned (yet).

--- a/brink/qm.py
+++ b/brink/qm.py
@@ -443,13 +443,14 @@ def merge_commit(args):
     * GITHUB_PULL_ID
     * GITHUB_TOKEN
     """
-    github_env = _get_github_environment()
-
     from github import GithubException
+
+    github_env = _get_github_environment()
 
     (repo, pull_request, message) = _check_review_properties(
         token=github_env['token'], pull_id=github_env['pull_id'])
 
+    branch_name = pull_request.head.ref
     remote_sha = pull_request.head.sha.lower()
 
     try:
@@ -464,7 +465,8 @@ def merge_commit(args):
             object=remote_sha,
             type='commit',
             )
-        print("\n> PR Merged\n")
+        print("\n> PR Merged for %s. Tag created at %s.\n" % (
+            branch_name, remote_sha,))
 
     except GithubException as error:
         print("\n> Failed to merge PR and create tag.\n")

--- a/brink/qm.py
+++ b/brink/qm.py
@@ -461,7 +461,7 @@ def merge_commit(args):
         except GitCommandError as error:
             print(error)
 
-        print('Set `origin` remote to %s and fetch' % (origin,))
+        print('\n> Set `origin` remote to %s and fetch\n' % (origin,))
         origin = repo.create_remote('origin', origin)
         print(origin)
         print(origin.fetch())
@@ -475,25 +475,25 @@ def merge_commit(args):
         # Merge branch into the landing branch.
 
         try:
-            print("Switch and reseting master.")
+            print("\n> Switch and reseting master.\n")
             print(repo.heads['master'].checkout())
             print(repo.head.reset('origin/master', hard=True))
         except IndexError:
-            print("We don't have a master branch. Create it.")
+            print("\n> We don't have a master branch. Create it.\n")
             master = repo.create_head('master', origin.refs.master)
             print(master)
             repo.head.set_reference(master)
 
-        print("Merge branch at %s " % (local_sha,))
+        print("\n> Merge branch at %s\n" % (local_sha,))
         print(git.merge(local_sha, squash=True, no_commit=True))
-        print("Commit message")
+        print("\n> Commit message\n")
         print(git.commit(author=author, message=message))
         # Push merged changes to landing branch.
         for state in repo.remotes.origin.push(
                 landing_ref, tags=update_tags):
             print(state.summary)
-            if '[rejected]' in state.summary:
-                print('Failed to push changes.')
+            if '[remote rejected]' in state.summary:
+                print('\n> Failed to push changes.')
                 sys.exit(1)
         # Delete original branch.
         print(repo.remotes.origin.push(branch_name, delete=True))

--- a/brink/qm.py
+++ b/brink/qm.py
@@ -459,11 +459,11 @@ def merge_commit(args):
             commit_title=pull_request.title,
             merge_method='squash',
             ))
-        print(repo.create_git_tag(
-            tag=SETUP['product']['version'],
-            message='Tag created by RQM',
-            object=remote_sha,
-            type='commit',
+        # We create the simple tag, without annotation as a ref.
+        # Low level git ftw.
+        print(repo.create_git_ref(
+            ref='refs/tags/' + SETUP['product']['version'],
+            sha=remote_sha,
             ))
         print("\n> PR Merged for %s. Tag created at %s.\n" % (
             branch_name, remote_sha,))

--- a/brink/qm.py
+++ b/brink/qm.py
@@ -137,8 +137,8 @@ def _check_review_properties(token, pull_id):
 
         # Fail early if branch can not be merged.
         if not pull_request.mergeable:
-            print("GitHub said that branch can not be merged.")
-            print("Please resolve the conflicts and push the changes.")
+            print("\n> GitHub said that branch can not be merged.")
+            print("Check PR %s for %s.\n" % (pull_id, branch_name))
             sys.exit(1)
 
         master = _get_protected_branch(repo, 'master')
@@ -454,17 +454,17 @@ def merge_commit(args):
     remote_sha = pull_request.head.sha.lower()
 
     try:
-        _pr_merge(
+        print(_pr_merge(
             pr=pull_request,
             commit_title=pull_request.title,
             merge_method='squash',
-            )
-        repo.create_git_tag(
+            ))
+        print(repo.create_git_tag(
             tag=SETUP['product']['version'],
             message='Tag created by RQM',
             object=remote_sha,
             type='commit',
-            )
+            ))
         print("\n> PR Merged for %s. Tag created at %s.\n" % (
             branch_name, remote_sha,))
 

--- a/brink/qm.py
+++ b/brink/qm.py
@@ -450,14 +450,13 @@ def merge_commit(args):
     (repo, pull_request, message) = _check_review_properties(
         token=github_env['token'], pull_id=github_env['pull_id'])
 
-    branch_name = _get_environment('BRANCH', repo.head.ref.name)
     remote_sha = pull_request.head.sha.lower()
     local_sha = repo.head.commit.hexsha
 
     # Fail early if branch can not be merged or at wrong commit.
     if remote_sha != local_sha:
         print("Local branch and review branch are at different revision.")
-        print("Local sha:  %s %s" % (local_sha, branch_name))
+        print("Local sha:  %s" % (local_sha,))
         print("Review sha: %s" % (remote_sha,))
         sys.exit(1)
 

--- a/brink/qm.py
+++ b/brink/qm.py
@@ -469,7 +469,7 @@ def merge_commit(args):
             branch_name, remote_sha,))
 
     except GithubException as error:
-        print("\n> Failed to merge PR and create tag.\n")
+        print("\n> Failed to merge PR and create the tag.\n")
         print(str(error))
         sys.exit(1)
 

--- a/brink/qm.py
+++ b/brink/qm.py
@@ -451,14 +451,6 @@ def merge_commit(args):
         token=github_env['token'], pull_id=github_env['pull_id'])
 
     remote_sha = pull_request.head.sha.lower()
-    local_sha = repo.head.commit.hexsha
-
-    # Fail early if branch can not be merged or at wrong commit.
-    if remote_sha != local_sha:
-        print("Local branch and review branch are at different revision.")
-        print("Local sha:  %s" % (local_sha,))
-        print("Review sha: %s" % (remote_sha,))
-        sys.exit(1)
 
     try:
         _pr_merge(

--- a/pavement.py
+++ b/pavement.py
@@ -405,6 +405,11 @@ def publish(args):
     Placeholder to test the whole publish process.
     """
     print("Publishing: %s" % (args,))
+    # We remove all the packages as this is what is usually done in publish.
+    pave.pip(
+        command='uninstall',
+        arguments=['--yes'] + BUILD_PACKAGES + TEST_PACKAGES + LINT_PACKAGES,
+        )
 
 
 @task

--- a/pavement.py
+++ b/pavement.py
@@ -279,9 +279,9 @@ def update_setup():
     """
     Updating of version at runtime for testing.
     """
-    SETUP['product']['version'] = '0.55.13'
+    SETUP['product']['version'] = '0.63.4'
     SETUP['product']['version_major'] = '0'
-    SETUP['product']['version_minor'] = '55'
+    SETUP['product']['version_minor'] = '63'
 
 
 @task

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -4,6 +4,12 @@ chevah-brink release notes
 Here are the release notes for past brink version.
 
 
+Version 0.64.0, 2017-08-13
+--------------------------
+
+* For RQM use GitHub API to do the merge.
+
+
 Version 0.63.4, 2017-07-26
 --------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 from setuptools import setup, find_packages, Command
 
 
-VERSION = u'0.63.4'
+VERSION = u'0.64.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

With the new change in PQM where we use github protected branches, the RQM fails as the merge commit is not tested.


Changes
=======

Use GitHub API to do the merge.


How to try and test the changes
===============================

reviewers: @hcs0 

Testing this is hard as he change is basically irreversible... and to reverse it you need to disable branch protection.

Send this branch to RQM  for landing on production and if successfully merged, then all is good.

Before the final send you can try to push changes and push before all tests were done, or before the review is done.

You can check the previous PR  like #110 and the buildbot logs