### PR TITLE
[#4508] Fix exception handling when publishing to coverator.

### DIFF
--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -517,8 +517,8 @@ def coverator_publish():
 
         try:
             upload_coverage(*args, url=SETUP['test']['coverator_url'])
-        except Exception:
-            print('Failed to upload coverage data:', sys.exc_info[0])
+        except Exception as error:
+            print('Failed to upload coverage data: %s' % error)
 
 
 def _generate_coverate_reports():

--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -517,7 +517,7 @@ def coverator_publish():
 
         try:
             upload_coverage(*args, url=SETUP['test']['coverator_url'])
-        except Exception as error:
+        except Exception as error:  # noqa: cover
             print('Failed to upload coverage data: %s' % error)
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 from setuptools import setup, find_packages, Command
 
 
-VERSION = u'0.67.3'
+VERSION = u'0.67.4'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

When publishing fails an internal error is raised instead of the correct handling.


Changes
=======

Fixed it, I have merged my code without implementing the suggestion in the review before. So this is a follow for the last PR.

Also update brink version.


How to try and test the changes
===============================

reviewers: @adiroiban 

Check if it makes sense.

Change the coverator url in pavement.py to another IP and see if it fails to publish the coverage but exits in a clean way.