### PR TITLE
Add support to run GitHub Action tests without a commit.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,9 +63,10 @@ jobs:
       run: mv build-brink build-brink-ț
 
     - name: Test
-      run: ./brink.sh test_ci
+      run: ./brink.sh test_ci ${{ github.event.input.tests }}
       env:
-        CHEVAH_BUILD: build-brink-ț ${{ github.event.input.tests }}
+        CHEVAH_BUILD: build-brink-ț
+
 
   osx-unicode-path:
     runs-on: macos-latest
@@ -100,10 +101,11 @@ jobs:
       run: mv build-brink build-brink-ț
 
     - name: Test
-      run: ./brink.sh test_ci
+      run: ./brink.sh test_ci ${{ github.event.input.tests }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         CHEVAH_BUILD: build-brink-ț
+
 
   windows:
     runs-on: windows-latest
@@ -112,6 +114,14 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
+
+    - name: Unpack diff
+      if: ${{ github.event.inputs.diff }}
+      run: |
+        [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String("${{ github.event.inputs.diff }}")) | Out-File -FilePath patch.diff
+        get-content patch.diff
+        git apply -v patch.diff
+
 
     - name: Fail on skip-ci
       if: ${{ github.event.after }}
@@ -128,6 +138,6 @@ jobs:
       run: sh ./brink.sh deps
 
     - name: Test
-      run: sh ./brink.sh test_ci
+      run: sh ./brink.sh test_ci ${{ github.event.input.tests }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,16 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      tests:
+        description: Run selected tests
+        default: ""
+        required: false
+      diff:
+        description: Diff in base64
+        default: ""
+        required: true
 
 jobs:
 
@@ -20,6 +30,13 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
+
+    - name: Unpack diff
+      if: ${{ github.event.inputs.diff }}
+      run: |
+        echo ${{ github.event.inputs.diff }} | base64 -d > patch.diff
+        cat patch.diff
+        git apply -v patch.diff
 
     - name: Fail on skip ci
       run: git log -1 --pretty=format:"%s" ${{ toJSON(github.event.after) }} | grep -v 'skip-ci'
@@ -37,7 +54,7 @@ jobs:
     - name: Test
       run: ./brink.sh test_ci
       env:
-        CHEVAH_BUILD: build-brink-ț
+        CHEVAH_BUILD: build-brink-ț ${{ github.event.input.tests }}
 
   osx-unicode-path:
     runs-on: macos-latest
@@ -46,6 +63,13 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
+
+    - name: Unpack diff
+      if: ${{ github.event.inputs.diff }}
+      run: |
+        echo ${{ github.event.inputs.diff }} | base64 -d > patch.diff
+        cat patch.diff
+        patch -p1 < patch.diff
 
     - name: Fail on skip ci
       run: git log -1 --pretty=format:"%s" ${{ toJSON(github.event.after) }} | grep -v 'skip ci'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
   linux_unicode_path:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
-    if: github.event.inputs.job == "" || github.job == github.event.inputs.job
+    if: github.event.inputs.job == '' || github.job == github.event.inputs.job
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   osx_unicode_path:
     runs-on: macos-latest
-    if: github.event.inputs.job == "" || github.job == github.event.inputs.job
+    if: github.event.inputs.job == '' || github.job == github.event.inputs.job
 
     steps:
     - uses: chevah/auto-cancel-redundant-job@v1
@@ -116,7 +116,7 @@ jobs:
 
   windows:
     runs-on: windows-latest
-    if: github.event.inputs.job == "" || github.job == github.event.inputs.job
+    if: github.event.inputs.job == '' || github.job == github.event.inputs.job
 
     steps:
     - uses: chevah/auto-cancel-redundant-job@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
 
   osx_unicode_path:
     runs-on: macos-latest
-    if: github.event.inputs.job == '' || github.job == github.event.inputs.job
+    if: github.event.inputs.job == '' || github.event.inputs.job == 'osx_unicode_path'
 
     steps:
     - uses: chevah/auto-cancel-redundant-job@v1
@@ -116,7 +116,7 @@ jobs:
 
   windows:
     runs-on: windows-latest
-    if: github.event.inputs.job == '' || github.job == github.event.inputs.job
+    if: github.event.inputs.job == '' || github.event.inputs.job == 'windows'
 
     steps:
     - uses: chevah/auto-cancel-redundant-job@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,9 +68,12 @@ jobs:
       run: mv build-brink build-brink-ț
 
     - name: Test
-      run: ./brink.sh test_ci ${{ github.event.input.tests }}
+      run: ./brink.sh test_ci ${{ github.event.inputs.tests }}
       env:
         CHEVAH_BUILD: build-brink-ț
+
+    - name: Move build back
+      run: mv build-brink-ț build-brink
 
 
   osx_unicode_path:
@@ -108,10 +111,13 @@ jobs:
       run: mv build-brink build-brink-ț
 
     - name: Test
-      run: ./brink.sh test_ci ${{ github.event.input.tests }}
+      run: ./brink.sh test_ci ${{ github.event.inputs.tests }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         CHEVAH_BUILD: build-brink-ț
+
+    - name: Move build back
+      run: mv build-brink-ț build-brink
 
 
   windows:
@@ -147,6 +153,6 @@ jobs:
       run: sh ./brink.sh deps
 
     - name: Test
-      run: sh ./brink.sh test_ci ${{ github.event.input.tests }}
+      run: sh ./brink.sh test_ci ${{ github.event.inputs.tests }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,9 @@ jobs:
 
     - name: Show action context
       run: |
-        echo "${{ toJSON(github.event) }}"
+        echo << EOF
+        ${{ toJSON(github.event) }}
+        EOF
 
     # Make sure we don't have multiple job
     - uses: chevah/auto-cancel-redundant-job@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,9 @@ jobs:
     steps:
 
     - name: Show action context
-      run: |
-        echo << EOF
-        ${{ toJSON(github) }}
-        EOF
+      env:
+        GITHUB_CONTEXT: ${{ toJSON(github) }}
+      run: echo $GITHUB_CONTEXT
 
     # Make sure we don't have multiple job
     - uses: chevah/auto-cancel-redundant-job@v1
@@ -45,10 +44,12 @@ jobs:
 
     - name: Unpack diff
       if: ${{ github.event.inputs.diff }}
+      env:
+        CHEVAH_DIFF: ${{ github.event.inputs.diff }}
       run: |
-        echo ${{ github.event.inputs.diff }} | base64 -d > patch.diff
-        cat patch.diff
+        echo $CHEVAH_DIFF | base64 -d > patch.diff
         git apply -v patch.diff
+        cat patch.diff
 
     - name: Fail on skip-ci
       if: ${{ github.event.after }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
   linux_unicode_path:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
-    if: ${{ github.job == github.event.inputs.job}}
+    if: github.event.inputs.job == "" || github.job == github.event.inputs.job
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   osx_unicode_path:
     runs-on: macos-latest
-    if: ${{ github.event.inputs.job == github.job }}
+    if: github.event.inputs.job == "" || github.job == github.event.inputs.job
 
     steps:
     - uses: chevah/auto-cancel-redundant-job@v1
@@ -116,7 +116,7 @@ jobs:
 
   windows:
     runs-on: windows-latest
-    if: ${{ github.event.inputs.job == github.job }}
+    if: github.event.inputs.job == "" || github.job == github.event.inputs.job
 
     steps:
     - uses: chevah/auto-cancel-redundant-job@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       with:
         path: |
           build-brink
-        key: ${{ runner.os }}-${{ hashFiles('pavement.py') }}
+        key: ${{ runner.os }}-${{ hashFiles('pavement.py') }}-${{ hashFiles('brink.conf') }}
 
     - name: Deps
       run: ./brink.sh deps
@@ -102,7 +102,7 @@ jobs:
       with:
         path: |
           build-brink
-        key: ${{ runner.os }}-${{ hashFiles('pavement.py') }}
+        key: ${{ runner.os }}-${{ hashFiles('pavement.py') }}-${{ hashFiles('brink.conf') }}
 
     - name: Deps
       run: ./brink.sh deps
@@ -147,7 +147,7 @@ jobs:
       with:
         path: |
           build-brink
-        key: ${{ runner.os }}-${{ hashFiles('pavement.py') }}
+        key: ${{ runner.os }}-${{ hashFiles('pavement.py') }}-${{ hashFiles('brink.conf') }}
 
     - name: Deps
       run: sh ./brink.sh deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,10 @@ on:
         description: Run selected tests
         default: ""
         required: false
+      job:
+        description: Specific job to execute
+        default: ""
+        required: false
       diff:
         description: Diff in base64
         default: ""
@@ -21,6 +25,7 @@ jobs:
   linux-unicode-path:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
+    if: ${{ github.event.inputs.job == github.job }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -70,6 +75,8 @@ jobs:
 
   osx-unicode-path:
     runs-on: macos-latest
+    if: ${{ github.event.inputs.job == github.job }}
+
     steps:
     - uses: chevah/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2
@@ -109,6 +116,8 @@ jobs:
 
   windows:
     runs-on: windows-latest
+    if: ${{ github.event.inputs.job == github.job }}
+
     steps:
     - uses: chevah/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,10 @@ jobs:
     steps:
 
     - name: Show action context
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: echo $GITHUB_CONTEXT
+      run: |
+        echo << EOF
+        ${{ toJSON(github) }}
+        EOF
 
     # Make sure we don't have multiple job
     - uses: chevah/auto-cancel-redundant-job@v1
@@ -44,12 +45,10 @@ jobs:
 
     - name: Unpack diff
       if: ${{ github.event.inputs.diff }}
-      env:
-        CHEVAH_DIFF: ${{ github.event.inputs.diff }}
       run: |
-        echo $CHEVAH_DIFF | base64 -d > patch.diff
-        git apply -v patch.diff
+        echo ${{ github.event.inputs.diff }} | base64 -d > patch.diff
         cat patch.diff
+        git apply -v patch.diff
 
     - name: Fail on skip-ci
       if: ${{ github.event.after }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,11 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+
+    - name: Show action context
+      run: |
+        echo "${{ toJSON(github.event) }}"
+
     # Make sure we don't have multiple job
     - uses: chevah/auto-cancel-redundant-job@v1
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -38,12 +43,10 @@ jobs:
         cat patch.diff
         git apply -v patch.diff
 
-    - name: Fail on skip ci
+    - name: Fail on skip-ci
+      if: ${{ github.event.after }}
       run: git log -1 --pretty=format:"%s" ${{ toJSON(github.event.after) }} | grep -v 'skip-ci'
 
-    - name: Show action context
-      run: |
-        echo "${{ toJSON(github.event) }}"
 
     - name: Deps
       run: ./brink.sh deps
@@ -71,11 +74,9 @@ jobs:
         cat patch.diff
         patch -p1 < patch.diff
 
-    - name: Fail on skip ci
+    - name: Fail on skip-ci
+      if: ${{ github.event.after }}
       run: git log -1 --pretty=format:"%s" ${{ toJSON(github.event.after) }} | grep -v 'skip ci'
-
-    - name: Fail on skip gha
-      run: git log -1 --pretty=format:"%s" ${{ toJSON(github.event.after) }} | grep -v 'skip gha'
 
     - name: Deps
       run: ./brink.sh deps
@@ -97,7 +98,8 @@ jobs:
       with:
         fetch-depth: 2
 
-    - name: Fail on skip ci
+    - name: Fail on skip-ci
+      if: ${{ github.event.after }}
       run: git log -1 --pretty=format:"%s" ${{ toJSON(github.event.after) }} | grep -v 'skip-ci'
 
     - name: Deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,10 @@ on:
 
 jobs:
 
-  linux-unicode-path:
+  linux_unicode_path:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
+    if: ${{ github.job == github.event.inputs.job}}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -72,7 +73,7 @@ jobs:
         CHEVAH_BUILD: build-brink-ț
 
 
-  osx-unicode-path:
+  osx_unicode_path:
     runs-on: macos-latest
     if: ${{ github.event.inputs.job == github.job }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
   linux_unicode_path:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
-    if: github.event.inputs.job == '' || github.job == github.event.inputs.job
+    if: github.event.inputs.job == '' || github.event.inputs.job == 'linux_unicode_path'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Show action context
       run: |
         echo << EOF
-        ${{ toJSON(github.event) }}
+        ${{ toJSON(github) }}
         EOF
 
     # Make sure we don't have multiple job
@@ -49,6 +49,12 @@ jobs:
       if: ${{ github.event.after }}
       run: git log -1 --pretty=format:"%s" ${{ toJSON(github.event.after) }} | grep -v 'skip-ci'
 
+    - name: Cache build
+      uses: actions/cache@v2
+      with:
+        path: |
+          build-brink
+        key: ${{ runner.os }}-${{ hashFiles('pavement.py') }}
 
     - name: Deps
       run: ./brink.sh deps
@@ -74,11 +80,18 @@ jobs:
       run: |
         echo ${{ github.event.inputs.diff }} | base64 -d > patch.diff
         cat patch.diff
-        patch -p1 < patch.diff
+        git apply -v patch.diff
 
     - name: Fail on skip-ci
       if: ${{ github.event.after }}
       run: git log -1 --pretty=format:"%s" ${{ toJSON(github.event.after) }} | grep -v 'skip ci'
+
+    - name: Cache build
+      uses: actions/cache@v2
+      with:
+        path: |
+          build-brink
+        key: ${{ runner.os }}-${{ hashFiles('pavement.py') }}
 
     - name: Deps
       run: ./brink.sh deps
@@ -103,6 +116,13 @@ jobs:
     - name: Fail on skip-ci
       if: ${{ github.event.after }}
       run: git log -1 --pretty=format:"%s" ${{ toJSON(github.event.after) }} | grep -v 'skip-ci'
+
+    - name: Cache build
+      uses: actions/cache@v2
+      with:
+        path: |
+          build-brink
+        key: ${{ runner.os }}-${{ hashFiles('pavement.py') }}
 
     - name: Deps
       run: sh ./brink.sh deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,14 +18,13 @@ on:
       diff:
         description: Diff in base64
         default: ""
-        required: true
+        required: False
 
 jobs:
 
   linux-unicode-path:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
-    if: ${{ github.event.inputs.job == github.job }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -1,3 +1,6 @@
+#
+# A workflow which is only availale for manual trigger.
+#
 name: Try-Patch
 
 on:
@@ -11,11 +14,6 @@ on:
         description: Diff in base64
         default: ""
         required: true
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-
 
 jobs:
 

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -11,6 +11,11 @@ on:
         description: Diff in base64
         default: ""
         required: true
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
 
 jobs:
 
@@ -21,19 +26,16 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
 
-    - name: Show action context
-      run: |
-        echo "${{ toJSON(github.event) }}"
-
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
 
     - name: Unpack diff
+      if: ${{ github.event.inputs.diff }}
       run: |
         echo ${{ github.event.inputs.diff }} | base64 -d > patch.diff
         cat patch.diff
-        patch -p1 < patch.diff
+        git apply -v patch.diff
 
     - name: Deps
       run: ./brink.sh deps

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,23 @@ you can merge from GitHub's merge button.
 The merge button will tell you if something is not right.
 
 
+Configuration file
+==================
+
+Configuration file used by command from here should be placed in
+`~/.config/chevah-brink.ini` and look like::
+
+    [actions]
+    token = GITHUT_PERSONAL_TOKEN
+
+    [buildbot]
+    server = YOUR.BUILDMASTER.ADDRESS
+    port = YOUR_BUILDMASTER_PORT
+    web_url = YOUR_BUILDMASTER_HTTP_STATUS_URL
+    username = BUILDMASTER_TRY_USERNAME
+    password = BUILDMASTER_TRY_PASSWORD
+
+
 Release Process
 ===============
 

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,19 @@ Configuration file used by command from here should be placed in
     password = BUILDMASTER_TRY_PASSWORD
 
 
+GitHub Token Permissions
+========================
+
+Part of the brink script will interact with GitHub and will need special
+permissions.
+
+Get a new token from https://github.com/settings/tokens/new
+
+Below are the permissions required for each part:
+
+* `actions-try`: repo (all)
+
+
 Release Process
 ===============
 

--- a/README.rst
+++ b/README.rst
@@ -39,11 +39,11 @@ The merge button will tell you if something is not right.
 Configuration file
 ==================
 
-Configuration file used by command from here should be placed in
-`~/.config/chevah-brink.ini` and look like::
+Configuration file used by commands in this repo should be saved as
+`~/.config/chevah-brink.ini` with the following format::
 
     [actions]
-    token = GITHUT_PERSONAL_TOKEN
+    token = GITHUB_PERSONAL_TOKEN
 
     [buildbot]
     server = YOUR.BUILDMASTER.ADDRESS
@@ -59,9 +59,9 @@ GitHub Token Permissions
 Part of the brink script will interact with GitHub and will need special
 permissions.
 
-Get a new token from https://github.com/settings/tokens/new
+Get a new token from https://github.com/settings/tokens/new.
 
-Below are the permissions required for each part:
+Permissions required for each part:
 
 * `actions-try`: repo (all)
 

--- a/brink.conf
+++ b/brink.conf
@@ -1,5 +1,5 @@
 # We are in brink itself, so we don't have to install brink.
-BASE_REQUIREMENTS='pip==20.1.1 setuptools==44.1.1 paver==1.2.4'
+BASE_REQUIREMENTS='setuptools==44.1.1 paver==1.2.4'
 PYTHON_CONFIGURATION='default@2.7.18.4b61bd67:sol10@2.7.8.4b61bd67'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com/packages/simple'

--- a/brink.conf
+++ b/brink.conf
@@ -1,5 +1,5 @@
 # We are in brink itself, so we don't have to install brink.
-BASE_REQUIREMENTS='pip==20.1.1 paver==1.2.4'
+BASE_REQUIREMENTS='pip==20.1.1 setuptools==44.1.1 paver==1.2.4'
 PYTHON_CONFIGURATION='default@2.7.18.4b61bd67:sol10@2.7.8.4b61bd67'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com/packages/simple'

--- a/brink.sh
+++ b/brink.sh
@@ -253,6 +253,7 @@ update_path_variables() {
     export CHEVAH_PYTHON=${PYTHON_NAME}
     export CHEVAH_OS=${OS}
     export CHEVAH_ARCH=${ARCH}
+    export CHEVAH_CACHE=${CACHE_FOLDER}
 
 }
 
@@ -410,7 +411,8 @@ get_python_dist() {
         # We have the requested python version.
         get_binary_dist $python_distributable $remote_base_url/${OS}/${ARCH}
     else
-        (>&2 echo "Requested version was not found on the remote server.")
+        echo "Requested version was not found on the remote server."
+        echo "$remote_base_url $python_distributable"
         exit 4
     fi
 }

--- a/brink.sh
+++ b/brink.sh
@@ -411,8 +411,8 @@ get_python_dist() {
         # We have the requested python version.
         get_binary_dist $python_distributable $remote_base_url/${OS}/${ARCH}
     else
-        echo "Requested version was not found on the remote server."
-        echo "$remote_base_url $python_distributable"
+        (>&2 echo "Requested version was not found on the remote server.")
+        (>&2 echo "$remote_base_url $python_distributable")
         exit 4
     fi
 }

--- a/brink/configuration.py
+++ b/brink/configuration.py
@@ -36,6 +36,9 @@ SETUP = {
         'vcs': 'git',
         'builders_filter': None,
         },
+    'actions': {
+        'token': '',
+        },
     'publish': {
         'download_production_hostname': 'download.chevah.com',
         'download_staging_hostname': 'staging.download.chevah.com',

--- a/brink/git_command.py
+++ b/brink/git_command.py
@@ -164,7 +164,6 @@ class BrinkGit(object):
         Return a list of (action, filename) that have changed in
         comparison with `ref`.
         """
-        result = []
         if ref:
             command = ['git', 'diff', '%s' % (ref)]
         else:

--- a/brink/git_command.py
+++ b/brink/git_command.py
@@ -157,3 +157,22 @@ class BrinkGit(object):
             result.append((action, name))
 
         return result
+
+    @staticmethod
+    def diff(ref='master'):
+        """
+        Return a list of (action, filename) that have changed in
+        comparison with `ref`.
+        """
+        result = []
+        if ref:
+            command = ['git', 'diff', '%s' % (ref)]
+        else:
+            command = ['git', 'diff']
+
+        exit_code, output = execute(command)
+        if exit_code != 0:
+            print('Failed to diff repo.')
+            sys.exit(1)
+
+        return output

--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -879,7 +879,7 @@ def actions_try(options):
             if run['status'] in ['in_progress', 'queue']:
                 in_progress.append(run)
             if debug:
-                print('Found %s: %s - %s' % (
+                print('Found run %s: %s - %s' % (
                     run['id'], run['status'], run['conclusion']))
 
         if in_progress:
@@ -907,6 +907,10 @@ def actions_try(options):
 
         url = '/actions/runs/%s' % (run['id'])
         result, _ = _github_api(url)
+
+        if debug:
+            print('Current run status: %s' % (result['status'],))
+
         if result['status'] == 'in_progress':
 
             if i % 5 == 0:

--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -785,6 +785,7 @@ def buildbot_list(args):
                 if selector in line:
                     print(line)
 
+
 def _github_api(url, method=b'GET', json=None):
     """
     Return the JSON response from GitHub API.
@@ -810,6 +811,7 @@ def _github_api(url, method=b'GET', json=None):
 @cmdopts([
     ('wait', 'w', 'Wait for run to execute and show the result'),
     ('action=', 'a', 'Name of workflow for which to execute the actions.'),
+    ('job=', 'j', 'Execute a specific job'),
     ('tests=', 't', 'Tests to execute'),
     ('step=', 's', 'Show output only for step'),
     ('debug', 'd', 'Show debug output'),
@@ -831,6 +833,7 @@ def actions_try(options):
 
     wait = options.actions_try.get('wait', False)
     tests = options.actions_try.get('tests', '')
+    job = options.actions_try.get('job', '')
     debug = options.actions_try.get('debug', False)
     target_step = options.actions_try.get('step', '')
     branch = pave.git.branch_name
@@ -850,8 +853,9 @@ def actions_try(options):
         'inputs': {
             'tests': tests,
             'diff': diff,
+            'job': job,
+            },
         }
-    }
 
     # Triggering the run will not give us any positive feedback.
     url = '/actions/workflows/%s/dispatches' % (target,)

--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -879,7 +879,7 @@ def actions_try(options):
             if run['status'] in ['in_progress', 'queue']:
                 in_progress.append(run)
             if debug:
-                print('Found run %s: %s - %s' % (
+                print('\tFound run %s: %s - %s' % (
                     run['id'], run['status'], run['conclusion']))
 
         if in_progress:
@@ -909,7 +909,7 @@ def actions_try(options):
         result, _ = _github_api(url)
 
         if debug:
-            print('Current run status: %s' % (result['status'],))
+            print('\tCurrent run status: %s' % (result['status'],))
 
         if result['status'] == 'in_progress':
 

--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -816,9 +816,6 @@ def _github_api(url, method=b'GET', json=None):
     ])
 def actions_try(options):
     '''Launch a try job on buildmaster.'''
-    if not options:
-        return actions_list()
-
     try:
         target = options.actions_try.action
     except AttributeError:
@@ -938,7 +935,8 @@ def actions_try(options):
             if not member.lower().endswith(target_name):
                 continue
             target_logs.append(member)
-    else:
+
+    if not target_logs:
         # Show output for all steps from each job.
         for member in members:
             if '/' in member:
@@ -950,18 +948,6 @@ def actions_try(options):
     for log in target_logs:
         with archive.open(log) as stream:
             print(stream.read())
-
-
-@task
-@consume_args
-def actions_list(args):
-    """
-    List all the workflows available on GitHub actions for remote trigger.
-    """
-    result, _ = _github_api('/actions/workflows')
-    for w in result['workflows']:
-        if w['name'].lower().startswith('try-'):
-            print(w['html_url'].rsplit('/')[-1])
 
 
 @task

--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -815,7 +815,14 @@ def _github_api(url, method=b'GET', json=None):
     ('debug', 'd', 'Show debug output'),
     ])
 def actions_try(options):
-    '''Launch a try job on buildmaster.'''
+    """
+    Manual trigger of workflow based on current branch uncommited diff.
+
+    Make sure to stage/add any new files.
+
+    It will automatically push the local branch to make sure remote and local
+    are on the same base.
+    """
     try:
         target = options.actions_try.action
     except AttributeError:

--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -31,6 +31,7 @@ import sys
 import subprocess
 import time
 from base64 import b64encode
+from datetime import datetime
 from io import BytesIO
 from zipfile import ZipFile
 
@@ -853,6 +854,8 @@ def actions_try(options):
         print('--workflow is required.')
         sys.exit(1)
 
+    command_start = datetime.now()
+
     trigger = options.actions_try.get('trigger', False)
     tests = options.actions_try.get('tests', '')
     job = options.actions_try.get('job', '')
@@ -1024,6 +1027,8 @@ def actions_try(options):
             print('  %s%s%s(%s): %s' % (
                 color, step['conclusion'], cend, duration, step['name']))
         print('-' * 72)
+
+    print('Total duration: %s' % (datetime.now() - command_start,))
 
 
 @task

--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -876,8 +876,11 @@ def actions_try(options):
 
         in_progress = []
         for run in result['workflow_runs']:
-            if run['status'] == 'in_progress':
+            if run['status'] in ['in_progress', 'queue']:
                 in_progress.append(run)
+            if debug:
+                print('Found %s: %s - %s' % (
+                    run['id'], run['status'], run['conclusion']))
 
         if in_progress:
             break

--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -818,6 +818,17 @@ def _parse_datetime(raw):
     import dateutil.parser as dp
     return dp.parse(raw)
 
+class TC:
+    """
+    Terminal colors.
+    """
+    BLUE = '\033[94m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    RED = '\033[91m'
+    END = '\033[0m'
+    BOLD = '\033[1m'
+
 
 @task
 @cmdopts([
@@ -996,11 +1007,23 @@ def actions_try(options):
         duration = end - start
         print('Duration: %s' % (duration,))
         for step in job['steps']:
-            print('  Step: %s - %s' % (step['name'], step['conclusion']))
             start = _parse_datetime(step['started_at'])
             end = _parse_datetime(step['completed_at'])
             duration = end - start
-            print('  Duration: %s' % (duration,))
+            color = ''
+            cend = ''
+            if step['conclusion'] == 'success':
+                color = TC.GREEN
+                cend = TC.END
+            elif step['conclusion'] == 'failure':
+                color = TC.RED
+                cend = TC.END
+            elif step['conclusion'] == 'skipped':
+                color = TC.YELLOW
+                cend = TC.END
+
+            print('  %s%s%s(%s): %s' % (
+                color, step['conclusion'], cend, duration, step['name']))
 
 
 @task

--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -31,9 +31,7 @@ import sys
 import subprocess
 import time
 from base64 import b64encode
-from datetime import datetime
 from io import BytesIO
-from pprint import pprint
 from zipfile import ZipFile
 
 from paver.easy import call_task, cmdopts, task, pushd, needs
@@ -818,6 +816,7 @@ def _parse_datetime(raw):
     import dateutil.parser as dp
     return dp.parse(raw)
 
+
 class TC:
     """
     Terminal colors.
@@ -999,8 +998,8 @@ def actions_try(options):
 
     result, _ = _github_api(completed['jobs_url'], absolute=True)
 
+    print('-' * 72)
     for job in result['jobs']:
-        print('-' * 72)
         print('Job: %s - %s' % (job['name'], job['conclusion']))
         start = _parse_datetime(job['started_at'])
         end = _parse_datetime(job['completed_at'])
@@ -1024,6 +1023,7 @@ def actions_try(options):
 
             print('  %s%s%s(%s): %s' % (
                 color, step['conclusion'], cend, duration, step['name']))
+        print('-' * 72)
 
 
 @task

--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -911,7 +911,7 @@ def actions_try(options):
         if debug:
             print('\tCurrent run status: %s' % (result['status'],))
 
-        if result['status'] == 'in_progress':
+        if result['status'] in ['in_progress', 'queued']:
 
             if i % 5 == 0:
                 # Reduce the output noise.

--- a/brink/pavement_commons.py
+++ b/brink/pavement_commons.py
@@ -876,7 +876,7 @@ def actions_try(options):
 
         in_progress = []
         for run in result['workflow_runs']:
-            if run['status'] in ['in_progress', 'queue']:
+            if run['status'] in ['in_progress', 'queued']:
                 in_progress.append(run)
             if debug:
                 print('\tFound run %s: %s - %s' % (
@@ -902,7 +902,7 @@ def actions_try(options):
     # Pool for run completion.
     sleep = 2
     completed = None
-    for i in range(120):
+    for i in range(300):
         time.sleep(sleep)
 
         url = '/actions/runs/%s' % (run['id'])

--- a/brink/tests/test_filesystem.py
+++ b/brink/tests/test_filesystem.py
@@ -44,7 +44,7 @@ class TestBrinkFilesystem(BrinkTestCase):
 
         result = self.sut.which(command, extra_paths=extra_paths)
 
-        self.assertIsNotNone(result)
+        self.assertIsNone(result)
 
     def test_which_extra_paths_file_found(self):
         """

--- a/brink/tests/test_filesystem.py
+++ b/brink/tests/test_filesystem.py
@@ -44,7 +44,7 @@ class TestBrinkFilesystem(BrinkTestCase):
 
         result = self.sut.which(command, extra_paths=extra_paths)
 
-        self.assertIsNone(result)
+        self.assertIsNotNone(result)
 
     def test_which_extra_paths_file_found(self):
         """

--- a/pavement.py
+++ b/pavement.py
@@ -15,6 +15,8 @@ import sys
 import warnings
 
 from brink.pavement_commons import (
+    actions_list,
+    actions_try,
     buildbot_list,
     buildbot_try,
     codecov_publish,
@@ -49,6 +51,8 @@ from paver.easy import call_task, consume_args, needs, no_help, pushd, task
 from paver.tasks import environment
 
 # Make pylint shut up.
+actions_list
+actions_try
 buildbot_list
 buildbot_try
 codecov_publish

--- a/pavement.py
+++ b/pavement.py
@@ -112,6 +112,8 @@ BUILD_PACKAGES = [
     'repoze.sphinx.autointerface==0.7.1.c4',
     # Docutils is required for RST parsing and for Sphinx.
     'docutils==0.12.c1',
+
+    'python-dateutil>=2.8.1',
     ]
 
 # Packages required to run the test suite.

--- a/pavement.py
+++ b/pavement.py
@@ -97,7 +97,7 @@ BUILD_PACKAGES = [
     'async==0.6.1',
     'gitdb==0.6.4',
     'gitpython==1.0.1',
-    'pygithub==1.45',
+    'pygithub==1.34.0',
 
     # For Lint and static checkers.
     'scame==0.5.1',

--- a/pavement.py
+++ b/pavement.py
@@ -15,7 +15,6 @@ import sys
 import warnings
 
 from brink.pavement_commons import (
-    actions_list,
     actions_try,
     buildbot_list,
     buildbot_try,
@@ -51,7 +50,6 @@ from paver.easy import call_task, consume_args, needs, no_help, pushd, task
 from paver.tasks import environment
 
 # Make pylint shut up.
-actions_list
 actions_try
 buildbot_list
 buildbot_try

--- a/pavement.py
+++ b/pavement.py
@@ -89,7 +89,7 @@ BUILD_PACKAGES = [
     # Buildbot is used for try scheduler
     'buildbot==0.8.11.chevah11',
 
-    'configparser==3.5.0b2',
+    'configparser==4.0.2',
     'towncrier==17.4.0.chevah2',
 
     # For PQM

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -4,6 +4,12 @@ chevah-brink release notes
 Here are the release notes for past brink version.
 
 
+Version 0.75.0, 2020-07-19
+--------------------------
+
+* Add support for GitHub actions try.
+
+
 Version 0.74.2, 2020-07-01
 --------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 from setuptools import setup, find_packages, Command
 
 
-VERSION = u'0.74.2'
+VERSION = u'0.75.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This add support to run tests on Github Actions without a commit.

It updates the pavement helpers and updates the GitHub actions configration.


Changes
=======

Update the workflow to handle manual runs...and job and test selection.

The try.yaml is there just for experiments.


How to try and test the changes
===============================

reviewers: @dumol 

Give it a try.

There are some differences from Buildbot.

We don't have `builders` but `workflows` and while a `builder` contains a single job on a single OS, a workflow can contain test runs on multiple OS (on a build matrix).

So a "workflow" is somehow similar to Buildbot projects and  a "job" is similar to a Buildbot builder. 
And both GitHub Actions and Buildbot have steps.

You run a specific workflow. This is required. 
You can optionally run only a specific job inside the workfow.
You can optionally run only a specific test suite inside the job or inside all the jobs.
You can optionally only show output a specific step inside the job or inside all the jobs.


```
$ paver actions_try --workflow=main.yml  --job=linux_unicode_path --step=test --test=test_filesystem
```

----------

Note that you can now also do a manual run of a test from the UI if you go at https://github.com/chevah/brink/actions?query=workflow%3ATry-Patch

For the GitHub-CI you will see the GitHub UI once this is merged in master